### PR TITLE
Use samba-tool instead of smbpasswd

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,12 +85,12 @@ class SmbpasswdRequestHandler(http.server.SimpleHTTPRequestHandler):
             http.server.SimpleHTTPRequestHandler.log_message(self, format, *args)
 
     def _call_smbpasswd(self, username, password):
-        args = ["sudo", "smbpasswd", "-s", username]
+        args = ["sudo", "samba-tool", "user", "setpassword","--newpassword="+password, username]
         if not _use_sudo:
             args = args[1:]
         try:
             proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-            _, std_err = proc.communicate(input=(password + "\n" + password + "\n").encode())
+            _, std_err = proc.communicate()
             if proc.returncode == 0:
                 return True
             else:


### PR DESCRIPTION
I need samba-tool instead of smbpasswd. I thought I'd share the changes with you. Sadly, I did not have time to add a CLI switch for this. But it could be interesting to support samba-tool instead of smbpasswd.

Anyways: thanks.