### PR TITLE
Add example systemd service file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Send this URL to your user(See note 2 in `Usage`).
 
 By default ***smbpasswd-web***  will bind to localhost:8443 when in SSL mode or localhost:8080 otherwise. Using a `nginx`(or alike) as a proxy is good advice. Also you can expose it in port 80 or 443 so the URL gets cleaner.
 
+### Running as systemd service
+To run this server as a simple systemd service, copy the `smbpasswd-web.service` file to `/etc/systemd/system/` and modify the paths according to your needs. Then execute
+```bash
+systemctl daemon-reload
+systemctl start smbpasswd-web.service
+systemctl enable smbpasswd-web.service
+```
+
 ### TODO
 
 Migrated to issues. PRs are welcome! :)

--- a/smbpasswd-web.service
+++ b/smbpasswd-web.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Web Daemon for changing Samba passwords
+
+[Service]
+ExecStart=/opt/smbpasswd-web/app.py server
+WorkingDirectory=/opt/smbpasswd-web
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I added an example for a systemd service file to run the daemon. This may be out of scope for your documentation or repo, but may be useful.